### PR TITLE
Lua 5.2 support by replacing setfenv

### DIFF
--- a/repl/init.lua
+++ b/repl/init.lua
@@ -25,11 +25,24 @@ local repl         = { _buffer = '', _plugins = setmetatable({}, plugins_lookup_
 local select       = select
 local loadstring   = loadstring
 local dtraceback   = debug.traceback
-local setfenv      = setfenv
 local setmetatable = setmetatable
 local sformat      = string.format
 local smatch       = string.match
 local error        = error
+
+setfenv = setfenv or function(f, t)
+    f = (type(f) == 'function' and f or debug.getinfo(f + 1, 'f').func)
+    local name
+    local up = 0
+    repeat
+        up = up + 1
+        name = debug.getupvalue(f, up)
+    until name == '_ENV' or name == nil
+    if name then
+debug.upvaluejoin(f, up, function() return t end, 1) -- use unique upvalue, set it to f
+    end
+end
+local setfenv = setfenv
 
 local function gather_results(success, ...)
   local n = select('#', ...)


### PR DESCRIPTION
repl doesn't work on 5.2 purely because the `setfenv` library function was removed. http://lua-users.org/lists/lua-l/2010-06/msg00313.html provides a replacement for `setfenv`; drop this in and repl works fine on 5.2.
