### PR TITLE
Improve support for Lua 5.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 	# TODO
 
 test:
-	LUA_INIT='' LUA_PATH=';;?.lua;?/init.lua;t/lib/?.lua' prove
+	LUA_INIT='' LUA_PATH=';;$(LUA_PATH);?.lua;?/init.lua;t/lib/?.lua' prove
 
 clean:
 	rm -rf doc/

--- a/repl/compat.lua
+++ b/repl/compat.lua
@@ -19,5 +19,8 @@
 return {
    -- unpack was moved to table.unpack on Lua version 5.2
    -- See https://www.lua.org/manual/5.2/manual.html#8
-   unpack = unpack or table.unpack
+   unpack = unpack or table.unpack,
+   -- loadstring was deprecated in favor of load, which was updated
+   -- to handle string arguments
+   loadstring = loadstring or load
 }

--- a/repl/compat.lua
+++ b/repl/compat.lua
@@ -16,42 +16,8 @@
 -- IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 -- CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
--- @class repl.console
---- This module implements a command line-based REPL,
---- similar to the standalone Lua interpreter.
-
-local sync_repl    = require 'repl.sync'
-local compat       = require 'repl.compat'
-local console_repl = sync_repl:clone()
-local stdout       = io.stdout
-local stdin        = io.stdin
-local print        = print
-local unpack       = unpack
-
--- @see repl:showprompt(prompt)
-function console_repl:showprompt(prompt)
-  stdout:write(prompt .. ' ')
-end
-
--- @see repl.sync:lines()
-function console_repl:lines()
-  return stdin:lines()
-end
-
--- @see repl:displayresults(results)
-function console_repl:displayresults(results)
-  if results.n == 0 then
-    return
-  end
-
-  print(compat.unpack(results, 1, results.n))
-end
-
--- @see repl:displayerror(err)
-function console_repl:displayerror(err)
-  print(err)
-end
-
-console_repl._features.console = true
-
-return console_repl
+return {
+   -- unpack was moved to table.unpack on Lua version 5.2
+   -- See https://www.lua.org/manual/5.2/manual.html#8
+   unpack = unpack or table.unpack
+}

--- a/repl/compat.lua
+++ b/repl/compat.lua
@@ -22,5 +22,9 @@ return {
    unpack = unpack or table.unpack,
    -- loadstring was deprecated in favor of load, which was updated
    -- to handle string arguments
-   loadstring = loadstring or load
+   loadstring = loadstring or load,
+   -- package.loaders was renamed package.searchers in Lua 5.2
+   package = {
+      searchers = package.loaders or package.searchers
+   }
 }

--- a/repl/init.lua
+++ b/repl/init.lua
@@ -22,8 +22,8 @@
 local plugins_lookup_meta = { __mode = 'k' }
 
 local repl         = { _buffer = '', _plugins = setmetatable({}, plugins_lookup_meta), _features = {}, _ifplugin = {}, _iffeature = {}, VERSION = 0.8 }
+local compat       = require 'repl.compat'
 local select       = select
-local loadstring   = loadstring
 local dtraceback   = debug.traceback
 local setmetatable = setmetatable
 local sformat      = string.format
@@ -249,7 +249,7 @@ local function setup_after(repl)
     repl[key] = function(...)
       local _, results = gather_results(true, old_value(...))
       value(...)
-      return unpack(results, 1, results.n)
+      return compat.unpack(results, 1, results.n)
     end
   end
 
@@ -401,7 +401,7 @@ function repl:loadplugin(chunk)
     end
   end
 
-  return unpack(results, 1, results.n)
+  return compat.unpack(results, 1, results.n)
 end
 
 -- XXX how to guarantee this gets called?

--- a/repl/init.lua
+++ b/repl/init.lua
@@ -84,7 +84,7 @@ function repl:detectcontinue(err)
 end
 
 function repl:compilechunk(chunk)
-  return loadstring(chunk, self:name())
+  return compat.loadstring(chunk, self:name())
 end
 
 --- Evaluates a line of input, and displays return value(s).

--- a/repl/init.lua
+++ b/repl/init.lua
@@ -329,7 +329,7 @@ end
 
 -- TODO use lua-procure for this (eventually)
 local function findchunk(name)
-  for _, loader in pairs(package.loaders or package.searchers) do
+  for _, loader in pairs(compat.package.searchers) do
     local chunk = loader(name)
 
     if type(chunk) == 'function' then

--- a/t/plugin-around-tests.lua
+++ b/t/plugin-around-tests.lua
@@ -1,5 +1,6 @@
 -- vim:foldmethod=marker
 local repl = require 'repl'
+local compat = require 'repl.compat'
 pcall(require, 'luarocks.loader')
 require 'Test.More'
 local utils = require 'test-utils'
@@ -24,7 +25,7 @@ do -- basic tests {{{
       ok(not has_called_normal)
       local return_values = utils.gather_results(orig(self, ...))
       ok(has_called_normal)
-      return unpack(return_values, 1, return_values.n)
+      return compat.unpack(return_values, 1, return_values.n)
     end
   end)
 


### PR DESCRIPTION
Hi,

I have made some changes to improve support for Lua 5.3. Specifically `table.unpack` is used if `unpack` is not available, similarly `load` is used if `loadstring` is not available.

I have also updated the Makefile a bit use user's `LUA_PATH`  while running the tests, this makes it possible to use [vert](https://github.com/aconbere/vert) for running tests against different Lua versions.

Also I was thinking of moving this compatibility hacks to a separate module (something like `repl.compat`)  so that rest of the code can remain free of these hacks, what do you think.

Thanks