### PR TITLE
Reset REPL buffer after errors when detectcontinue() says no input is pending.

### DIFF
--- a/repl/init.lua
+++ b/repl/init.lua
@@ -110,6 +110,7 @@ function repl:handleline(line)
       return 2
     else
       self:displayerror(err)
+      self._buffer = ''
     end
   end
 


### PR DESCRIPTION
Hello, I noticed that I wasn't able to recover after inputting a syntax error (notably, an unclosed `"`-quoted string).
I believe this one-liner is the desired fix. Here is an example session before and after applying it, just to show what I'm talking about. 

```
[justinb@galago ~]$ # BEFORE
[justinb@galago ~]$ rep.lua 
Lua REPL 0.9
> "hello
>> world"
[string "REPL"]:1: unfinished string near '"hello'
> -- Oops, how silly of me. Let's try something else.
[string "REPL"]:1: unfinished string near '"hello'
> 1 + 1
[string "REPL"]:1: unfinished string near '"hello'
> "
[string "REPL"]:1: unfinished string near '"hello'
> eat flaming death
[string "REPL"]:1: unfinished string near '"hello'
> 
[justinb@galago ~]$ # AFTER
[justinb@galago ~]$ rep.lua 
Lua REPL 0.9
> "hello
>> world"
[string "REPL"]:1: unfinished string near '"hello'
> -- Oops, how silly of me. Let's try something else.
> 1 + 1
2
> -- Yay!
> 
```